### PR TITLE
Use public instead private.

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -16,12 +16,12 @@ services:
         arguments:
             - "@mybuilder.cronos_bundle.process_runner"
             - "@mybuilder.cronos_bundle.filesystem"
-        private: true
+        public: false
 
     mybuilder.cronos_bundle.process_runner:
         class: MyBuilder\Cronos\Updater\SymfonyProcessRunner
-        private: true
+        public: false
 
     mybuilder.cronos_bundle.filesystem:
         class: MyBuilder\Cronos\Updater\SymfonyFileSystem
-        private: true
+        public: false


### PR DESCRIPTION
Fix deprecation notices in Symfony 3.1 projects:

The configuration key "private" is unsupported for service definition "mybuilder.cronos_bundle.cron_manipulator" in "services.yml". Allowed configuration keys are "alias", "parent", "class", "shared", "synthetic", "lazy", "public", "abstract", "deprecated", "factory", "file", "arguments", "properties", "configurator", "calls", "tags", "decorates", "decoration_inner_name", "decoration_priority", "autowire", "autowiring_types". The YamlFileLoader object will raise an exception instead in Symfony 4.0 when detecting an unsupported service configuration key: 1x
    1x in DefaultControllerTest::testIndex from Tests\AppBundle\Controller

The configuration key "private" is unsupported for service definition "mybuilder.cronos_bundle.process_runner" in "services.yml". Allowed configuration keys are "alias", "parent", "class", "shared", "synthetic", "lazy", "public", "abstract", "deprecated", "factory", "file", "arguments", "properties", "configurator", "calls", "tags", "decorates", "decoration_inner_name", "decoration_priority", "autowire", "autowiring_types". The YamlFileLoader object will raise an exception instead in Symfony 4.0 when detecting an unsupported service configuration key: 1x
    1x in DefaultControllerTest::testIndex from Tests\AppBundle\Controller

The configuration key "private" is unsupported for service definition "mybuilder.cronos_bundle.filesystem" in "services.yml". Allowed configuration keys are "alias", "parent", "class", "shared", "synthetic", "lazy", "public", "abstract", "deprecated", "factory", "file", "arguments", "properties", "configurator", "calls", "tags", "decorates", "decoration_inner_name", "decoration_priority", "autowire", "autowiring_types". The YamlFileLoader object will raise an exception instead in Symfony 4.0 when detecting an unsupported service configuration key: 1x
    1x in DefaultControllerTest::testIndex from Tests\AppBundle\Controller