### PR TITLE
Updated documented Symfony version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/mybuilder/cronos-bundle.svg?branch=master)](https://travis-ci.org/mybuilder/cronos-bundle)
 
-A bundle for Symfony 2 that allows you to use `@Cron` annotations to configure when cron should run your console commands.
+A bundle for Symfony 2/3 that allows you to use `@Cron` annotations to configure when cron should run your console commands.
 
 Uses the [Cronos](https://github.com/mybuilder/cronos) library to do the actual output and updating.
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "mybuilder/cronos-bundle",
-    "description": "Symfony 2 bundle which allows you to use @Cron annotations to configure cron to run your console commands.",
+    "description": "Symfony 2/3 bundle which allows you to use @Cron annotations to configure cron to run your console commands.",
     "keywords": ["cron", "cronos"],
     "minimum-stability": "stable",
     "license": "MIT",


### PR DESCRIPTION
Cronos supports both Symfony 2 and 3, however, the documentation states that it is only a bundle for 2.