### PR TITLE
[BUGFIX] Solved link to absolute paths with spaces

### DIFF
--- a/Exporter/AnnotationCronExporter.php
+++ b/Exporter/AnnotationCronExporter.php
@@ -120,7 +120,7 @@ class AnnotationCronExporter
             $executor = '';
         }
 
-        $console = isset($this->config['console']) ? ' ' . $this->config['console'] : '';
+        $console = isset($this->config['console']) ? ' ' . str_replace(' ', '\ ', $this->config['console']) : '';
         $environment = isset($options['environment']) ? ' --env=' . $options['environment'] : '';
         $params = $annotation->params ? ' ' . $annotation->params : '';
         return $executor . $console . ' ' . $commandName . $params . $environment;


### PR DESCRIPTION
**Example output before change:**
```
/usr/local/bin/php /Users/ketelaar/Projects/My Project/bin/console 
```
This basically means you are executing `/Users/ketelaar/Projects/My` with php

**Example output after change:**
```
/usr/local/bin/php /Users/ketelaar/Projects/My\ Project/bin/console 
```