### PR TITLE
ISSUE-32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea
 composer.lock
 composer.phar
 bin/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 composer.lock
 composer.phar
 bin/

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ Uses the [Cronos](https://github.com/mybuilder/cronos) library to do the actual 
 
 ## Installation
 
+**Note:** If you use Symfony 3 or higher you should replace `app/console` with `bin/console`.
+
 ### Install with composer
 
 Run the composer require command:
 
-``` bash
+```bash
 $ php composer.phar require mybuilder/cronos-bundle
 ```
 
@@ -20,7 +22,7 @@ $ php composer.phar require mybuilder/cronos-bundle
 
 Enable the bundle in the `app/AppKernel.php`:
 
-``` php
+```php
 public function registerBundles() {
     $bundles = array(
         new MyBuilder\Bundle\CronosBundle\MyBuilderCronosBundle(),

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -9,13 +9,11 @@ services:
 
     mybuilder.cronos_bundle.command.dump:
         class: MyBuilder\Bundle\CronosBundle\Command\DumpCommand
-        public: false
         tags:
             - { name: 'console.command' }
 
     mybuilder.cronos_bundle.command.replace:
         class: MyBuilder\Bundle\CronosBundle\Command\ReplaceCommand
-        public: false
         tags:
             - { name: 'console.command' }
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,5 +1,4 @@
 services:
-
     mybuilder.cronos_bundle.annotation_cron_exporter:
         class: MyBuilder\Bundle\CronosBundle\Exporter\AnnotationCronExporter
         public: true
@@ -7,6 +6,18 @@ services:
             - "@annotation_reader"
         calls:
             - [ setConfig, ["%mybuilder.cronos_bundle.exporter_config%"] ]
+
+    mybuilder.cronos_bundle.command.dump:
+        class: MyBuilder\Bundle\CronosBundle\Command\DumpCommand
+        public: false
+        tags:
+            - { name: 'console.command' }
+
+    mybuilder.cronos_bundle.command.replace:
+        class: MyBuilder\Bundle\CronosBundle\Command\ReplaceCommand
+        public: false
+        tags:
+            - { name: 'console.command' }
 
     mybuilder.cronos_bundle.cron_process_updater:
         class: MyBuilder\Cronos\Updater\CronUpdater


### PR DESCRIPTION
resolve #32
- Register `cronos:dump` and `cronos:replace` in the service container.
- Added `.idea` into `.gitignore`.
- Little correction for the documentation.