### PR TITLE
Fix removed `kernel.root_dir`

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -4,6 +4,7 @@ namespace MyBuilder\Bundle\CronosBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 class Configuration implements ConfigurationInterface
 {
@@ -17,6 +18,14 @@ class Configuration implements ConfigurationInterface
             // Symfony 3
             $treeBuilder = new TreeBuilder();
             $rootNode = $treeBuilder->root('my_builder_cronos');
+        }
+
+        if (method_exists(Kernel::class, 'getProjectDir')) {
+            // `kernel.project_dir` available since Symfony 3.3
+            $pathToConsole = '%kernel.project_dir%/bin/console';
+        } else {
+            // `kernel.root_dir` dropped in Symfony 5
+            $pathToConsole = '%kernel.root_dir%/../bin/console';
         }
 
         $rootNode
@@ -47,7 +56,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
                         ->scalarNode('console')
                             ->cannotBeEmpty()
-                            ->defaultValue('%kernel.root_dir%/../bin/console')
+                            ->defaultValue($pathToConsole)
                             ->example('%kernel.project_dir%/bin/console')
                             ->info('Allows you to specify the console that all commands should be passed to such as "bin/console".')
                         ->end()

--- a/Tests/DependencyInjection/MyBuilderCronosExtensionTest.php
+++ b/Tests/DependencyInjection/MyBuilderCronosExtensionTest.php
@@ -6,6 +6,7 @@ use MyBuilder\Bundle\CronosBundle\DependencyInjection\MyBuilderCronosExtension;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Yaml\Yaml;
 
 class MyBuilderCronosExtensionTest extends TestCase
@@ -34,11 +35,17 @@ class MyBuilderCronosExtensionTest extends TestCase
 
     public function providerTestConfig(): array
     {
+        if (method_exists(Kernel::class, 'getProjectDir')) {
+            $pathToConsole = '%kernel.project_dir%/bin/console';
+        } else {
+            $pathToConsole = '%kernel.root_dir%/../bin/console';
+        }
+
         return [
             [
                 [
                     'executor' => 'php',
-                    'console' => '%kernel.root_dir%/../bin/console',
+                    'console' => $pathToConsole,
                 ],
                 'empty.yml',
             ],

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,11 @@
         "mybuilder/cronos": "~3.0",
         "doctrine/annotations": "1.*",
         "symfony/console": "~3.0||^4.0||^5.0",
+        "symfony/config": "~3.0||^4.0||^5.0",
+        "symfony/dependency-injection": "~3.0||^4.0||^5.0",
         "symfony/framework-bundle": "~3.0||^4.0||^5.0",
-        "symfony/yaml": "3.0||^4.0||^5.0",
+        "symfony/http-kernel": "~3.0||^4.0||^5.0",
+        "symfony/yaml": "~3.0||^4.0||^5.0",
         "symfony/property-access": "~3.0||^4.0||^5.0",
         "php": ">=7.3"
     },


### PR DESCRIPTION
Fixes a bug using the bundle with Symfony 5, where `Kernel::getRootDir()` has been removed.

Fixes issue https://github.com/mybuilder/cronos-bundle/issues/37